### PR TITLE
fix node-pre-gyp spawn on windows with node 18+

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -26,11 +26,13 @@ module.exports = function install() {
   }
 
   return new Promise(function(resolve, reject) {
+    const gypPath = path.join(__dirname, "..", "node_modules", "node-gyp", "bin", "node-gyp.js");
     var spawnedNodePreGyp = spawn(nodePreGyp, args, {
-      env: Object.assign({}, process.env, {
-        npm_config_node_gyp: path.join(__dirname, "..", "node_modules",
-          "node-gyp", "bin", "node-gyp.js")
-      })
+      env: {
+        ...process.env,
+        npm_config_node_gyp: gypPath
+      },
+      shell: process.platform === "win32"
     });
 
     spawnedNodePreGyp.stdout.on("data", function(data) {


### PR DESCRIPTION
spawning cmd files without shell: true wasn't really allowed before, but not it's expressly disallowed because of a recent vulnerability reported to node