### PR TITLE
Add Linux ARM runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         node: [18, 20, 22]
-    runs-on: ubuntu-latest
+        runner: ["ubuntu-24.04", "ubuntu-24.04-arm"] 
+    runs-on: ${{ matrix.runner }}
     container: ubuntu:20.04
     steps:
       - name: Install Dependencies for Ubuntu


### PR DESCRIPTION
Add support for Linux `arm64` builds, to support using `@figma/nodegit` on ARM servers.

This seems like it was added in the past and then removed? I can't find this commit in the history anymore:
https://github.com/figma/nodegit/pull/7