### PR TITLE
chore: fix install script for Windows

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -26,12 +26,13 @@ module.exports = function install() {
   }
 
   return new Promise(function(resolve, reject) {
+    const gypPath = path.join(__dirname, "..", "node_modules", "node-gyp", "bin", "node-gyp.js");
     var spawnedNodePreGyp = spawn(nodePreGyp, args, {
-      shell: process.platform === "win32",
-      env: Object.assign({}, process.env, {
-        npm_config_node_gyp: path.join(__dirname, "..", "node_modules",
-          "node-gyp", "bin", "node-gyp.js")
-      })
+      env: {
+        ...process.env,
+        npm_config_node_gyp: gypPath
+      },
+      shell: process.platform === "win32"
     });
 
     spawnedNodePreGyp.stdout.on("data", function(data) {

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -27,6 +27,7 @@ module.exports = function install() {
 
   return new Promise(function(resolve, reject) {
     var spawnedNodePreGyp = spawn(nodePreGyp, args, {
+      shell: process.platform === "win32",
       env: Object.assign({}, process.env, {
         npm_config_node_gyp: path.join(__dirname, "..", "node_modules",
           "node-gyp", "bin", "node-gyp.js")
@@ -60,6 +61,6 @@ if (require.main === module) {
     .catch(function(e) {
       console.error("[nodegit] ERROR - Could not finish install");
       console.error("[nodegit] ERROR - finished with error code: " + e);
-      process.exit(e);
+      process.exit(1);
     });
 }


### PR DESCRIPTION
## Description
Fix `install.js` for Windows users. 
* `shell:true` is necessary for `spawn`ing due to https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
* `process.exit()` must take an integer, not an error object

This is a nice-to-have since likely `pnpm install` didn't work on Windows in the first place.

EDIT: It actually seems this was partially upstreamed in https://github.com/nodegit/nodegit/commit/c12c5a423808e427056d67e0f9b53af8034927c1

## Test Plan
Vibes right now.... would love to know how to test this out
